### PR TITLE
Add option to save index into buffer instead of file

### DIFF
--- a/c/lib.cpp
+++ b/c/lib.cpp
@@ -120,8 +120,9 @@ USEARCH_EXPORT usearch_index_t usearch_init(usearch_init_options_t* options, use
 
 USEARCH_EXPORT void usearch_free(usearch_index_t index, usearch_error_t*) { delete reinterpret_cast<index_t*>(index); }
 
-USEARCH_EXPORT void usearch_save(usearch_index_t index, char const* path, usearch_error_t* error) {
-    serialization_result_t result = reinterpret_cast<index_t*>(index)->save(path);
+USEARCH_EXPORT void usearch_save(usearch_index_t index, char const* path, char** usearch_result_buf,
+                                 usearch_error_t* error) {
+    serialization_result_t result = reinterpret_cast<index_t*>(index)->save(path, usearch_result_buf);
     if (!result)
         *error = result.error.what();
 }

--- a/c/test.c
+++ b/c/test.c
@@ -204,7 +204,7 @@ void test_save_load(size_t vectors_count, size_t vector_dimension, float const* 
     }
 
     // Save and free the index
-    usearch_save(idx, "usearch_index.bin", &error);
+    usearch_save(idx, "usearch_index.bin", NULL, &error);
     ASSERT(!error, error);
     usearch_free(idx, &error);
     ASSERT(!error, error);
@@ -249,7 +249,7 @@ void test_view(size_t vectors_count, size_t vector_dimension, float const* data)
     }
 
     // Save and free the index
-    usearch_save(idx, "usearch_index.bin", &error);
+    usearch_save(idx, "usearch_index.bin", NULL, &error);
     ASSERT(!error, error);
     usearch_free(idx, &error);
     ASSERT(!error, error);

--- a/c/usearch.h
+++ b/c/usearch.h
@@ -65,7 +65,7 @@ USEARCH_EXPORT typedef struct {
 USEARCH_EXPORT usearch_index_t usearch_init(usearch_init_options_t*, usearch_error_t*);
 USEARCH_EXPORT void usearch_free(usearch_index_t, usearch_error_t*);
 
-USEARCH_EXPORT void usearch_save(usearch_index_t, char const* path, usearch_error_t*);
+USEARCH_EXPORT void usearch_save(usearch_index_t, char const* path, char** usearch_result_buf, usearch_error_t*);
 USEARCH_EXPORT void usearch_load(usearch_index_t, char const* path, usearch_error_t*);
 USEARCH_EXPORT void usearch_view(usearch_index_t, char const* path, usearch_error_t*);
 USEARCH_EXPORT void usearch_view_mem(usearch_index_t index, char* data, usearch_error_t* error);

--- a/include/usearch/index_punned_dense.hpp
+++ b/include/usearch/index_punned_dense.hpp
@@ -416,7 +416,9 @@ class index_punned_dense_gt {
      *  @param[in] path The path to the file.
      *  @return Outcome descriptor explictly convertable to boolean.
      */
-    serialization_result_t save(char const* path) const { return typed_->save(path); }
+    serialization_result_t save(char const* path, char** usearch_result_buf) const {
+        return typed_->save(path, usearch_result_buf);
+    }
 
     /**
      *  @brief Parses the index from file to RAM.


### PR DESCRIPTION
## Description
Added argument `usearch_result_buf` to `usearch_save` function, so the function will check if the pointer is passed it will allocate a buffer, collect the index information into it and pass it's reference to user passed argument.