### PR TITLE
Expose usearch distance functions in C bindings

### DIFF
--- a/c/lib.cpp
+++ b/c/lib.cpp
@@ -326,3 +326,11 @@ USEARCH_EXPORT void usearch_cast(usearch_scalar_kind_t from, void const* vector,
     }
 }
 }
+
+USEARCH_EXPORT float usearch_dist(void const* a, void const* b, usearch_metric_kind_t metric, int dims,
+                                  usearch_scalar_kind_t kind) {
+    index_punned_dense_metric_t m = index_t::make_metric_(to_native_metric(metric), dims, to_native_scalar(kind));
+    punned_vector_view_t av = {reinterpret_cast<byte_t const*>(a), dims * bytes_per_scalar(to_native_scalar(kind))};
+    punned_vector_view_t bv = {reinterpret_cast<byte_t const*>(b), dims * bytes_per_scalar(to_native_scalar(kind))};
+    return m(av, bv);
+}

--- a/c/usearch.h
+++ b/c/usearch.h
@@ -110,6 +110,8 @@ USEARCH_EXPORT void usearch_add_external(                                       
 
 USEARCH_EXPORT void usearch_cast(usearch_scalar_kind_t from, void const* vector, usearch_scalar_kind_t to, void* result,
                                  size_t result_size, int dims, usearch_error_t* error);
+USEARCH_EXPORT float usearch_dist(void const* a, void const* b, usearch_metric_kind_t metric, int dims,
+                                  usearch_scalar_kind_t kind);
 
 #ifdef __cplusplus
 }

--- a/include/usearch/index_punned_dense.hpp
+++ b/include/usearch/index_punned_dense.hpp
@@ -750,6 +750,21 @@ class index_punned_dense_gt {
     }
 #endif
 
+    static metric_t make_metric_(metric_kind_t kind, std::size_t dimensions, scalar_kind_t accuracy) {
+        switch (kind) {
+        case metric_kind_t::ip_k: return ip_metric_(dimensions, accuracy);
+        case metric_kind_t::cos_k: return cos_metric_(dimensions, accuracy);
+        case metric_kind_t::l2sq_k: return l2sq_metric_(dimensions, accuracy);
+        case metric_kind_t::pearson_k: return pearson_metric_(accuracy);
+        case metric_kind_t::haversine_k: return haversine_metric_(accuracy);
+        case metric_kind_t::hamming_k: return hamming_gt<b1x8_t>{};
+        case metric_kind_t::jaccard_k: // Equivalent to Tanimoto
+        case metric_kind_t::tanimoto_k: return tanimoto_gt<b1x8_t>{};
+        case metric_kind_t::sorensen_k: return sorensen_gt<b1x8_t>{};
+        default: return {};
+        }
+    }
+
   private:
     struct thread_lock_t {
         index_punned_dense_gt const& parent;
@@ -1061,21 +1076,6 @@ class index_punned_dense_gt {
         case scalar_kind_t::f16_k: return pearson_correlation_gt<f16_t, f32_t>{};
         case scalar_kind_t::f32_k: return pearson_correlation_gt<f32_t>{};
         case scalar_kind_t::f64_k: return pearson_correlation_gt<f64_t>{};
-        default: return {};
-        }
-    }
-
-    static metric_t make_metric_(metric_kind_t kind, std::size_t dimensions, scalar_kind_t accuracy) {
-        switch (kind) {
-        case metric_kind_t::ip_k: return ip_metric_(dimensions, accuracy);
-        case metric_kind_t::cos_k: return cos_metric_(dimensions, accuracy);
-        case metric_kind_t::l2sq_k: return l2sq_metric_(dimensions, accuracy);
-        case metric_kind_t::pearson_k: return pearson_metric_(accuracy);
-        case metric_kind_t::haversine_k: return haversine_metric_(accuracy);
-        case metric_kind_t::hamming_k: return hamming_gt<b1x8_t>{};
-        case metric_kind_t::jaccard_k: // Equivalent to Tanimoto
-        case metric_kind_t::tanimoto_k: return tanimoto_gt<b1x8_t>{};
-        case metric_kind_t::sorensen_k: return sorensen_gt<b1x8_t>{};
         default: return {};
         }
     }


### PR DESCRIPTION
This can then be used to directly used usearch's optimized distance functions. 
Lantern example diff:
```
@@ -179,6 +179,7 @@ static float4 calc_distance(ArrayType *a, ArrayType *b)
     if(a_dim != b_dim) {
         elog(ERROR, "expected equally sized arrays but got arrays with dimensions %d and %d", a_dim, b_dim);
     }
+    return usearch_dist(ax, bx, usearch_metric_l2sq_k, a_dim, usearch_scalar_f32_k);

     return l2sq_dist_impl(ax, bx, a_dim);
 }
```
