### PR TITLE
Save ef options in header, set options when loading from file

### DIFF
--- a/c/lib.cpp
+++ b/c/lib.cpp
@@ -39,6 +39,21 @@ metric_kind_t to_native_metric(usearch_metric_kind_t kind) {
     }
 }
 
+usearch_metric_kind_t to_usearch_metric(metric_kind_t kind) {
+    switch (kind) {
+    case metric_kind_t::ip_k: return usearch_metric_ip_k;
+    case metric_kind_t::l2sq_k: return usearch_metric_l2sq_k;
+    case metric_kind_t::cos_k: return usearch_metric_cos_k;
+    case metric_kind_t::haversine_k: return usearch_metric_haversine_k;
+    case metric_kind_t::pearson_k: return usearch_metric_pearson_k;
+    case metric_kind_t::jaccard_k: return usearch_metric_jaccard_k;
+    case metric_kind_t::hamming_k: return usearch_metric_hamming_k;
+    case metric_kind_t::tanimoto_k: return usearch_metric_tanimoto_k;
+    case metric_kind_t::sorensen_k: return usearch_metric_sorensen_k;
+    default: return usearch_metric_unknown_k;
+    }
+}
+
 scalar_kind_t to_native_scalar(usearch_scalar_kind_t kind) {
     switch (kind) {
     case usearch_scalar_f32_k: return scalar_kind_t::f32_k;
@@ -194,6 +209,18 @@ USEARCH_EXPORT size_t usearch_dimensions(usearch_index_t index, usearch_error_t*
 
 USEARCH_EXPORT size_t usearch_connectivity(usearch_index_t index, usearch_error_t*) {
     return reinterpret_cast<index_t*>(index)->connectivity();
+}
+
+USEARCH_EXPORT size_t usearch_expansion_add(usearch_index_t index, usearch_error_t*) {
+    return reinterpret_cast<index_t*>(index)->expansion_add();
+}
+
+USEARCH_EXPORT size_t usearch_expansion_search(usearch_index_t index, usearch_error_t*) {
+    return reinterpret_cast<index_t*>(index)->expansion_search();
+}
+
+USEARCH_EXPORT usearch_metric_kind_t usearch_metric_kind(usearch_index_t index, usearch_error_t*) {
+    return to_usearch_metric(reinterpret_cast<index_t*>(index)->metric().kind());
 }
 
 USEARCH_EXPORT void usearch_reserve(usearch_index_t index, size_t capacity, usearch_error_t*) {

--- a/c/usearch.h
+++ b/c/usearch.h
@@ -81,6 +81,9 @@ USEARCH_EXPORT size_t usearch_size(usearch_index_t, usearch_error_t*);
 USEARCH_EXPORT size_t usearch_capacity(usearch_index_t, usearch_error_t*);
 USEARCH_EXPORT size_t usearch_dimensions(usearch_index_t, usearch_error_t*);
 USEARCH_EXPORT size_t usearch_connectivity(usearch_index_t, usearch_error_t*);
+USEARCH_EXPORT size_t usearch_expansion_add(usearch_index_t, usearch_error_t*);
+USEARCH_EXPORT size_t usearch_expansion_search(usearch_index_t, usearch_error_t*);
+USEARCH_EXPORT usearch_metric_kind_t usearch_metric_kind(usearch_index_t, usearch_error_t*);
 
 USEARCH_EXPORT void usearch_reserve(usearch_index_t, size_t capacity, usearch_error_t*);
 


### PR DESCRIPTION
## Description
Exported `usearch_expansion_add` `usearch_expansion_search` `usearch_metric_kind` getter functions, to be used from C interface.

Added `expansion_search` `expansion_add` props into usearch header (each 64bit), so now header size is 80 byte.
On `load` function we will now reload the `ef` options and `metric_kind` based on the header data.