### PR TITLE
Use externally passed postgres tid to identify neighbors

### DIFF
--- a/c/usearch.h
+++ b/c/usearch.h
@@ -19,7 +19,7 @@ USEARCH_EXPORT typedef float usearch_distance_t;
 USEARCH_EXPORT typedef char const* usearch_error_t;
 
 USEARCH_EXPORT typedef usearch_distance_t (*usearch_metric_t)(void const*, void const*);
-USEARCH_EXPORT typedef void* (*usearch_node_retriever_t)(void* ctx, int index);
+USEARCH_EXPORT typedef void* (*usearch_node_retriever_t)(void* ctx, uint64_t index);
 
 USEARCH_EXPORT typedef enum usearch_metric_kind_t {
     usearch_metric_ip_k = 0,
@@ -109,8 +109,9 @@ USEARCH_EXPORT int32_t usearch_newnode_level(usearch_index_t index, usearch_erro
 USEARCH_EXPORT void usearch_set_node_retriever(usearch_index_t index, void* retriever_ctx,
                                                usearch_node_retriever_t retriever,
                                                usearch_node_retriever_t retriever_mut, usearch_error_t* error);
-USEARCH_EXPORT void usearch_add_external(                                                                     //
-    usearch_index_t index, usearch_label_t label, void const* vector, void* tape, usearch_scalar_kind_t kind, //
+USEARCH_EXPORT void usearch_add_external( //
+    usearch_index_t index, usearch_label_t label, void const* vector, void* tape, void const* index_tid,
+    usearch_scalar_kind_t kind, //
     int32_t level, usearch_error_t* error);
 
 USEARCH_EXPORT void usearch_cast(usearch_scalar_kind_t from, void const* vector, usearch_scalar_kind_t to, void* result,


### PR DESCRIPTION
Usearch assumes nodes are stored sequentially in an in memory array. 
In Lantern, we get rid of the in memory storage and store usearch nodes in a postgres index.
Postgres index elements are identified by 48 bit tuple ids (BlockNumber + OffsetNumber)

We used to maintain a mapping between Usearch sequential ids and postgres tuple ids (tids).
This PR removes the need of such mapping.
This PR allows us to pass inserted tuple tid into Usearch so usearch can use that in neighbor list in place of the sequential id. 