### PR TITLE
Make scalar_size static to address a strange double inclusion bug

### DIFF
--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -162,7 +162,7 @@ template <typename scalar_at> scalar_kind_t common_scalar_kind() noexcept {
     return scalar_kind_t::unknown_k;
 }
 
-uint8_t scalar_size(scalar_kind_t kind) noexcept {
+static uint8_t scalar_size(scalar_kind_t kind) noexcept {
     switch (kind) {
     case scalar_kind_t::b1x8_k: return 1;
     case scalar_kind_t::f8_k: return 8;


### PR DESCRIPTION
Make scalar_size static to address a strange double inclusion bug manifesting in rust

Rust linker error details (when building lanterndb_extras)
44.61           /root/.cargo/git/checkouts/usearch-be18b6473dcdaf16/19cf475/include/usearch/index.hpp:165: multiple definition of `unum::usearch::scalar_size(unum::usearch::scalar_kind_t)'; /app/lanterndb_extras/target/debug/deps/libusearch-3defceb72bb27051.rlib(0762e6236c29c9f0-lib.rs.o):/root/.cargo/git/checkouts/usearch-be18b6473dcdaf16/19cf475/include/usearch/index.hpp:165: first defined here