### PR TITLE
Removed exposed usearch_newnode_level function

### DIFF
--- a/c/lib.cpp
+++ b/c/lib.cpp
@@ -250,10 +250,6 @@ USEARCH_EXPORT void usearch_add(                                                
         *error = result.error.what();
 }
 
-int32_t usearch_newnode_level(usearch_index_t index, usearch_error_t*) {
-    return reinterpret_cast<index_t*>(index)->newnode_level();
-}
-
 void usearch_add_external(                                                                                    //
     usearch_index_t index, usearch_label_t label, void const* vector, void* tape, usearch_scalar_kind_t kind, //
     int32_t level, usearch_error_t* error) {


### PR DESCRIPTION
Removed the exposed `usearch_newnode_level_function` since this [lantern PR](https://github.com/lanterndata/lantern/pull/172) proposes to rewrite it there.