### PR TITLE
Avoid unnecessary reservation of visitor list when visitor list has i…

### DIFF
--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -3228,9 +3228,6 @@ class index_gt {
                 prefetch(missing_candidates.begin(), missing_candidates.end());
             }
 
-            // Assume the worst-case when reserving memory
-            if (!visits.reserve(visits.size() + candidate_neighbors.size()))
-                return false;
 
             for (compressed_slot_t successor_slot : candidate_neighbors) {
                 if (visits.set(successor_slot))
@@ -3297,9 +3294,6 @@ class index_gt {
                 prefetch(missing_candidates.begin(), missing_candidates.end());
             }
 
-            // Assume the worst-case when reserving memory
-            if (!visits.reserve(visits.size() + candidate_neighbors.size()))
-                return false;
 
             for (compressed_slot_t successor_slot : candidate_neighbors) {
                 if (visits.set(successor_slot))


### PR DESCRIPTION
…ndex size

Earlier we switched visitor tracking implementation from hashset to bitset (see ec4cb7ebd515e1a24146075cb6a87212bc3c45a1)

The lines removed in this commit were needed then since visitor list was allocated incrementally.

However, when using bitset, we allocate bits for all nodes in the graph so there is no need to grow the visitor set over time