### PR TITLE
Narek/hnsw heuristic fix

### DIFF
--- a/cpp/bench.cpp
+++ b/cpp/bench.cpp
@@ -626,7 +626,7 @@ int main(int argc, char** argv) {
 
     if (args.skip_pruned) {
         std::printf("-- Skip pruned: true\n");
-        config.keep_pruned = false;
+        config.skip_pruned_connections = true;
     }
 
     if (args.big)

--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -1142,7 +1142,7 @@ struct index_config_t {
     /// when there are more than "connectivity" candidates
     /// when keep_pruned is set to true, the neighbor list of the heuristic is augmented
     /// with some of the pruned neighbors to fill as many of node neighbor slots as possible
-    bool keep_pruned = true;
+    bool skip_pruned_connections = false;
 
     inline index_config_t() = default;
     inline index_config_t(std::size_t c) noexcept
@@ -3381,7 +3381,7 @@ class index_gt {
             }
 
             if (good) {
-                if (config_.keep_pruned) {
+                if (config_.skip_pruned_connections) {
                     std::swap(top_data[submitted_count], top_data[consumed_count]);
                 } else {
                     // q:: this breaks the sorted_buffer data structure invariant, no?
@@ -3392,10 +3392,10 @@ class index_gt {
             consumed_count++;
         }
 
-        if (config_.keep_pruned) {
-            top.shrink(std::max(submitted_count, needed));
-        } else {
+        if (config_.skip_pruned_connections) {
             top.shrink(submitted_count);
+        } else {
+            top.shrink(std::max(submitted_count, needed));
         }
 
         return {top_data, top.size()};

--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -3222,7 +3222,6 @@ class index_gt {
                 break;
 
             next.pop();
-            context.iteration_cycles++;
 
             compressed_slot_t candidate_slot = candidacy.slot;
             if (new_slot == candidate_slot)
@@ -3242,6 +3241,7 @@ class index_gt {
                 if (visits.set(successor_slot))
                     continue;
 
+                context.iteration_cycles++;
                 // node_lock_t successor_lock = node_lock_(successor_slot);
                 distance_t successor_dist = context.measure(query, citerator_at(successor_slot), metric);
                 if (top.size() < top_limit || successor_dist < radius) {
@@ -3293,7 +3293,6 @@ class index_gt {
                 break;
 
             next.pop();
-            context.iteration_cycles++;
 
             neighbors_ref_t candidate_neighbors = neighbors_base_(storage_->get_node_at(candidate.slot));
 
@@ -3308,6 +3307,7 @@ class index_gt {
                 if (visits.set(successor_slot))
                     continue;
 
+                context.iteration_cycles++;
                 distance_t successor_dist = context.measure(query, citerator_at(successor_slot), metric);
                 if (top.size() < top_limit || successor_dist < radius) {
                     // This can substantially grow our priority queue:


### PR DESCRIPTION
[Fix member access count in search and insertion](https://github.com/Ngalstyan4/usearch/commit/5b7aef031f6890009842a29ac02f5f26fb19f736) 

Context variable iteration_cycles is used to count number of graph
node accesses per query (search, insert, etc)

In search_for_one_ the variable is properly updated every time a graph
node is accessed

However, in two codepaths the variable update happens outside of
inner-most graph node access loop, resulting in miscounted member
accesses. This commit fixes the counting

[Add comparisons/sec visits/query metrics to benchmark](https://github.com/Ngalstyan4/usearch/commit/f4aca7a433669e93e07b6aba65fc07464af3458d)

[Make connection pruning control name more consistent](https://github.com/Ngalstyan4/usearch/commit/bb5bc5443d654d02a90c00631d25ed4c864ab9d0)